### PR TITLE
Add select all and clear all options for filters

### DIFF
--- a/components/MapComponent.vue
+++ b/components/MapComponent.vue
@@ -297,7 +297,7 @@
      changeCurrentProperty: function (property) {
        this.Filtering.updateCurrentProperty(property);
        this.setAllIcons();
-     }
+     },
    },
   mounted: function() {
     let noWitches = 0;

--- a/components/filter-components/IconDependentFiltersList.vue
+++ b/components/filter-components/IconDependentFiltersList.vue
@@ -78,7 +78,7 @@ export default {
   },
   data() {
     return {
-      filtersList: JSON.parse(JSON.stringify(this.filterTypes))
+      filtersList: this.filterTypes
     }
   },
   methods: {

--- a/components/filter-components/MapFilters.vue
+++ b/components/filter-components/MapFilters.vue
@@ -152,7 +152,17 @@
 
               <!-- Filters list if property is showing. -->
               <div v-if="propertyItem.showing" class="w-full">
-                <icon-dependent-filters-list 
+                <button
+                    @click="selectAll(property, propertyItem)"
+                    class="inline-block rounded hover:bg-gray-200 bg-white text-black px-2 pb-1.5 pt-1.5 text-xs uppercase leading-normal shadow-[0_4px_9px_-4px_rgba(51,45,45,0.7)]">
+                  Select All
+                </button>
+                <button
+                    @click="clearAll(property, propertyItem)"
+                    class="inline-block rounded hover:bg-gray-800 bg-black text-white px-2 pb-1.5 pt-1.5 text-xs uppercase leading-normal shadow-[0_4px_9px_-4px_rgba(51,45,45,0.7)]">
+                  Clear All
+                </button>
+                <icon-dependent-filters-list
                   v-if="!iconsConstant"
                   :currentProperty="currentProperty"
                   :property="property"
@@ -162,7 +172,7 @@
                   @filterOn="emitFilterOn($event)"
                   @setPropertyToCurrent="setPropertyToCurrent($event)">
                 </icon-dependent-filters-list>
-                
+
                 <normal-filters-list
                   v-else :property="property"
                   :filterTypes="propertyItem.filters"
@@ -320,6 +330,24 @@
        if (this.iconBehaviour !== "constant") {
          this.$emit("changeCurrentProperty", property);
        }
+     },
+     selectAll: function (property, propertyItem) {
+       let filtersList = Object.keys(propertyItem.filters)
+
+       filtersList.forEach(type => {
+         propertyItem.filters[type].active = true
+         let filterInfo = [property, type]
+         this.$emit("filterOn", filterInfo);
+       })
+     },
+     clearAll: function (property, propertyItem) {
+       let filtersList = Object.keys(propertyItem.filters)
+
+       filtersList.forEach(type => {
+         propertyItem.filters[type].active = false
+         let filterInfo = [property, type]
+         this.$emit("filterOff", filterInfo);
+       })
      },
      togglePropertyShowing: function (property) {
        // If the property <property> is not showing, sets to showing,

--- a/components/filter-components/MapFilters.vue
+++ b/components/filter-components/MapFilters.vue
@@ -154,12 +154,12 @@
               <div v-if="propertyItem.showing" class="w-full">
                 <button
                     @click="selectAll(property, propertyItem)"
-                    class="inline-block rounded hover:bg-gray-200 bg-white text-black px-2 pb-1.5 pt-1.5 text-xs uppercase leading-normal shadow-[0_4px_9px_-4px_rgba(51,45,45,0.7)]">
+                    class="inline-block rounded hover:bg-gray-200 bg-white text-black px-2 pb-1.5 pt-1.5 text-xs  leading-normal ">
                   Select All
                 </button>
                 <button
                     @click="clearAll(property, propertyItem)"
-                    class="inline-block rounded hover:bg-gray-800 bg-black text-white px-2 pb-1.5 pt-1.5 text-xs uppercase leading-normal shadow-[0_4px_9px_-4px_rgba(51,45,45,0.7)]">
+                    class="inline-block rounded hover:bg-gray-200 bg-white text-black px-2 pb-1.5 pt-1.5 text-xs  leading-normal ">
                   Clear All
                 </button>
                 <icon-dependent-filters-list

--- a/components/filter-components/NormalFiltersList.vue
+++ b/components/filter-components/NormalFiltersList.vue
@@ -30,7 +30,7 @@ export default {
   },
   data() {
     return {
-      filtersList: JSON.parse(JSON.stringify(this.filterTypes))
+      filtersList: this.filterTypes
     }
   },
   methods: {


### PR DESCRIPTION
Allow users to select all filter property types e.g male, female, unknown at once. Or clear all filter property types all at once.