### PR TITLE
adding scroll back in

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -91,7 +91,7 @@ p {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   position: relative;
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -91,7 +91,8 @@ p {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  overflow: hidden; 
+  overflow-y: scroll;
+  overflow-x: hidden;
   position: relative;
 }
 


### PR DESCRIPTION
This scrollbar makes the difference on each page:

**Under Accused Witches**
Witchcraft Prosecutions In Time and Place( shows only when time line showing)
Timeline Search (can see full thing now)
Places of Residence Visualised using ArcGIS Online (shows always -gives more space to see them but interferes with the zooming in and out of map)
Number of Accused Witches That Resided In Each Modern Civil Parish (shows always - gives more space to see them but interferes with the zooming in and out of map)
Linking Residence to Place of Death(shows but isn't really necessary)

**Under Investigations**
Primary and Secondary Characterisations (shows only when time line showing)

**Trials**
Named Witches (allows to see whole thing)
Number of Trials Recorded in Each Authority (shows always -gives more space to see them but interferes with the zooming in and out of map)

**People Involved**
People Associated with the Witch Trials: Residence (gives more space to see them but interferes with the zooming in and out of map)
People Associated with the Witch Trials: Residence and Occupation  (gives more space to see them but interferes with the zooming in and out of map)
The Journey of a Witch-Pricker - John Kincaid of Tranent (gives more space to see them but interferes with the zooming in and out of map)

**Extra Visualisations**
Accused Witches Occupations with Unknown Values (can see full contents)
Types of Torture at Different Residence Locations (gives more space to see them but interferes with the zooming in and out of map)
Social Class with Unknown Values (now can see full contents)
